### PR TITLE
Use fetchApi instead of raw fetch

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,4 +1,8 @@
-import { createApiRef, DiscoveryApi } from '@backstage/core-plugin-api'
+import {
+  createApiRef,
+  DiscoveryApi,
+  FetchApi,
+} from '@backstage/core-plugin-api'
 
 export interface harborApi {}
 
@@ -8,14 +12,17 @@ export const harborApiRef = createApiRef<harborApi>({
 
 export type Options = {
   discoveryApi: DiscoveryApi
+  fetchApi: FetchApi
   proxyPath?: string
 }
 
 export class HarborApiClient implements harborApi {
   // @ts-ignore
   private readonly discoveryApi: DiscoveryApi
+  private readonly fetchApi: FetchApi
 
   constructor(options: Options) {
     this.discoveryApi = options.discoveryApi
+    this.fetchApi = options.fetchApi
   }
 }

--- a/src/components/HarborRepository/HarborRepository.tsx
+++ b/src/components/HarborRepository/HarborRepository.tsx
@@ -1,5 +1,5 @@
 import { Progress, Table } from '@backstage/core-components'
-import { configApiRef, useApi } from '@backstage/core-plugin-api'
+import { configApiRef, fetchApiRef, useApi } from '@backstage/core-plugin-api'
 import React, { useState } from 'react'
 import ReactSpeedometer from 'react-d3-speedometer'
 import { useAsync } from 'react-use'
@@ -11,10 +11,11 @@ export function HarborRepository(props: RepositoryProps) {
   const [repository, setRepository] = useState<Repository[]>([])
 
   const config = useApi(configApiRef)
+  const fetchApi = useApi(fetchApiRef)
   const backendUrl = config.getString('backend.baseUrl')
 
   const { loading } = useAsync(async () => {
-    const response = await fetch(
+    const response = await fetchApi.fetch(
       `${backendUrl}/api/harbor/artifacts?project=${props.project}&repository=${props.repository}`
     )
     const json = await response.json()

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -4,6 +4,7 @@ import {
   createComponentExtension,
   createPlugin,
   discoveryApiRef,
+  fetchApiRef,
 } from '@backstage/core-plugin-api'
 import { HarborApiClient, harborApiRef } from './api'
 import { HARBOR_ANNOTATION_REPOSITORY } from './components/useHarborAppData'
@@ -17,8 +18,9 @@ export const harborPlugin = createPlugin({
   apis: [
     createApiFactory({
       api: harborApiRef,
-      deps: { discoveryApi: discoveryApiRef },
-      factory: ({ discoveryApi }) => new HarborApiClient({ discoveryApi }),
+      deps: { discoveryApi: discoveryApiRef, fetchApi: fetchApiRef },
+      factory: ({ discoveryApi, fetchApi }) =>
+        new HarborApiClient({ discoveryApi, fetchApi }),
     }),
   ],
 })


### PR DESCRIPTION
Use fetchApi instead of raw fetch in order to pass auth header if necessary.
This makes the Harbor plugin compatible with the [Authenticate API Requests tutorial](https://github.com/backstage/backstage/blob/master/contrib/docs/tutorials/authenticate-api-requests.md)
