### PR TITLE
Parse date in frontend instead of backend

### DIFF
--- a/src/components/HarborRepository/HarborRepository.tsx
+++ b/src/components/HarborRepository/HarborRepository.tsx
@@ -24,6 +24,10 @@ export function HarborRepository(props: RepositoryProps) {
       setError(true)
       setErrorMsg(json.error.message)
     }
+
+    json.pushTime = new Date(json.pushTime).toLocaleDateString()
+    json.pullTime = new Date(json.pullTime).toLocaleDateString()
+
     setRepository(json)
   }, [props.project, props.repository])
 

--- a/src/components/HarborRepository/tableHeadings.tsx
+++ b/src/components/HarborRepository/tableHeadings.tsx
@@ -54,7 +54,7 @@ export const columns: TableColumn[] = [
     field: 'repoUrl',
     render: (rowData: any) => (
       <Button
-        to={`${rowData.repoUrl}/artifacts/${rowData.tag}`}
+        to={`${rowData.repoUrl}/artifacts-tab/artifacts/${rowData.tag}`}
         color="primary"
         variant="contained"
       >

--- a/src/components/HarborRepository/tableHeadings.tsx
+++ b/src/components/HarborRepository/tableHeadings.tsx
@@ -54,7 +54,7 @@ export const columns: TableColumn[] = [
     field: 'repoUrl',
     render: (rowData: any) => (
       <Button
-        to={`${rowData.repoUrl}/artifacts-tab/artifacts/${rowData.tag}`}
+        to={`${rowData.repoUrl}/artifacts/${rowData.tag}`}
         color="primary"
         variant="contained"
       >


### PR DESCRIPTION
Parsing the date in the frontend allows us to use native browser APIs to display time relative to the user's local timezone and locale.

This also removes the dependency of momentjs in the backend (see https://github.com/container-registry/backstage-plugin-harbor-backend/pull/110#issuecomment-1732551598)