### PR TITLE
Add support for multiple Harbor instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,61 +63,7 @@ const overviewContent = (
 
 ### Enabling backend
 
-```bash
-yarn --cwd packages/backend add @bestsellerit/backstage-plugin-harbor-backend
-```
-
-Create a new file named `packages/backend/src/plugins/harbor.ts`, and add the following to it
-
-```ts
-import { createRouter } from '@bestsellerit/backstage-plugin-harbor-backend'
-import { Router } from 'express'
-import { PluginEnvironment } from '../types'
-
-export default async function createPlugin({
-  logger,
-  config,
-}: PluginEnvironment): Promise<Router> {
-  return await createRouter({ logger, config })
-}
-```
-
-And finally, wire this into the overall backend router. Edit `packages/backend/src/index.ts`
-
-```ts
-import harbor from './plugins/harbor';
-// ...
-async function main() {
-  // ...
-  const harborEnv = useHotMemoize(module, () => createEnv('harbor'));
-  apiRouter.use('/harbor', await harbor(harborEnv));
-
-```
-
-## Configuration
-
-The plugin requires configuration in the Backstage app-config.yaml to connect to harbors API.
-
-```yaml
-harbor:
-  baseUrl: https://harbor.yourdomain.com
-  username:
-    $env: HARBOR_USERNAME
-  password:
-    $env: HARBOR_PASSWORD
-```
-
-Adding annotations and values to your component file.
-
-```yaml
-apiVersion: backstage.io/v1alpha1
-kind: Component
-metadata:
-  name: sample-component
-  description: 'A sample component with Harbor'
-  annotations:
-    goharbor.io/repository-slug: project/repository
-```
+See [backstage-plugin-harbor-backend](https://github.com/container-registry/backstage-plugin-harbor-backend#enabling-backend).
 
 ## Contributing
 

--- a/src/components/HarborDashboardPage/HarborDashboardPage.tsx
+++ b/src/components/HarborDashboardPage/HarborDashboardPage.tsx
@@ -2,20 +2,32 @@ import { useEntity } from '@backstage/plugin-catalog-react'
 import React from 'react'
 import { HarborRepository } from '../HarborRepository'
 import { useHarborAppData } from '../useHarborAppData'
+import { Grid } from '@material-ui/core'
 
 export const HarborDashboardPage = () => {
   const { entity } = useEntity()
   const { repositorySlug } = useHarborAppData({ entity })
-  const info = repositorySlug.split('/')
-
-  const project = info.shift() as 'string'
-  const repository = info.join('/')
 
   return (
-    <HarborRepository
-      project={project}
-      repository={repository}
-      widget={false}
-    />
+    <Grid container spacing={3}>
+      {repositorySlug.split(', ').map((slug) => {
+        const info = slug.split('/')
+        const host: string = info.length > 2 ? info.shift() : ''
+        const project: string = info.shift()
+        const repository: string = info.join('/')
+
+        return (
+          <Grid item xs={12}>
+            <HarborRepository
+              title={`${host}${host ? '/' : ''}${project}/${repository}`}
+              host={host}
+              project={project}
+              repository={repository}
+              widget={false}
+            />
+          </Grid>
+        )
+      })}
+    </Grid>
   )
 }

--- a/src/components/HarborRepository/HarborRepository.test.jsx
+++ b/src/components/HarborRepository/HarborRepository.test.jsx
@@ -49,6 +49,7 @@ describe('Harbor Repository', () => {
       render(
         <TestApiProvider apis={[[configApiRef, configApi]]}>
           <HarborRepository
+            host="host"
             project="project"
             repository="component"
             widget={false}

--- a/src/components/HarborRepository/HarborRepository.tsx
+++ b/src/components/HarborRepository/HarborRepository.tsx
@@ -15,9 +15,11 @@ export function HarborRepository(props: RepositoryProps) {
   const backendUrl = config.getString('backend.baseUrl')
 
   const { loading } = useAsync(async () => {
-    const response = await fetchApi.fetch(
-      `${backendUrl}/api/harbor/artifacts?project=${props.project}&repository=${props.repository}`
-    )
+    let fetchUrl = `${backendUrl}/api/harbor/artifacts?project=${props.project}&repository=${props.repository}`
+    if (props.host) {
+      fetchUrl = fetchUrl.concat(`&host=${props.host}`)
+    }
+    const response = await fetchApi.fetch(fetchUrl)
     const json = await response.json()
 
     if (json.hasOwnProperty('error')) {
@@ -74,7 +76,9 @@ export function HarborRepository(props: RepositoryProps) {
       >
         <ReactSpeedometer
           value={severityNumber}
-          width={450}
+          width={300}
+          height={200}
+          ringWidth={50}
           minValue={0}
           maxValue={500}
           segmentColors={[
@@ -85,7 +89,9 @@ export function HarborRepository(props: RepositoryProps) {
             '#ff471a',
           ]}
           customSegmentStops={[0, 100, 200, 300, 400, 500]}
-          currentValueText="vulnerability levels"
+          currentValueText={`${props.host}${props.host ? '/' : ''}${
+            props.project
+          }/${props.repository}`}
           customSegmentLabels={[
             {
               text: 'None',
@@ -125,6 +131,7 @@ HarborRepository.defaultProps = {
 }
 interface RepositoryProps {
   widget: boolean
+  host: string
   project: string
   repository: string
   title: string

--- a/src/components/HarborWidget/HarborWidget.tsx
+++ b/src/components/HarborWidget/HarborWidget.tsx
@@ -1,7 +1,7 @@
 import { Entity } from '@backstage/catalog-model'
 import { MissingAnnotationEmptyState } from '@backstage/core-components'
 import { useEntity } from '@backstage/plugin-catalog-react'
-import { Card, CardHeader } from '@material-ui/core'
+import { Card, CardHeader, Grid } from '@material-ui/core'
 import React from 'react'
 import { isHarborAvailable } from '../../plugin'
 import { HarborRepository } from '../HarborRepository'
@@ -12,15 +12,29 @@ import {
 
 const Widget = ({ entity }: { entity: Entity }) => {
   const { repositorySlug } = useHarborAppData({ entity })
-  const info = repositorySlug.split('/')
-
-  const project = info.shift() as 'string'
-  const repository = info.join('/')
 
   return (
     <Card>
-      <CardHeader title="Docker Image" />
-      <HarborRepository project={project} repository={repository} widget />
+      <CardHeader title="Vulnerabilities in Docker Images" />
+      <Grid container>
+        {repositorySlug.split(', ').map((slug) => {
+          const info = slug.split('/')
+          const host: string = info.length > 2 ? info.shift() : ''
+          const project: string = info.shift()
+          const repository: string = info.join('/')
+
+          return (
+            <Grid item>
+              <HarborRepository
+                host={host}
+                project={project}
+                repository={repository}
+                widget
+              />
+            </Grid>
+          )
+        })}
+      </Grid>
     </Card>
   )
 }


### PR DESCRIPTION
This PR adds the functionality to support multiple Harbor instances as described in https://github.com/container-registry/backstage-plugin-harbor/issues/219.

### Backend PR
https://github.com/container-registry/backstage-plugin-harbor-backend/pull/111

### UI
![list](https://github.com/container-registry/backstage-plugin-harbor/assets/9420018/3c9bc9ef-b5d5-424b-9737-4e7927ce8138)
![widget-1](https://github.com/container-registry/backstage-plugin-harbor/assets/9420018/87153d0f-eb85-453f-b93f-11b8fdf979ab)
![widget-2](https://github.com/container-registry/backstage-plugin-harbor/assets/9420018/19cd41d6-1631-4c0b-ada3-9f0ca8bf251a)
![widget-3](https://github.com/container-registry/backstage-plugin-harbor/assets/9420018/40f02e0b-8939-49b0-8cb8-a50859af36f4)
