### PR TITLE
Fix harbor widget description string

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,14 +11,13 @@
     "types": "dist/index.d.ts"
   },
   "scripts": {
-    "build": "backstage-cli plugin:build",
-    "start": "backstage-cli plugin:serve",
-    "lint": "backstage-cli lint",
-    "test": "backstage-cli test",
-    "diff": "backstage-cli plugin:diff",
-    "prepack": "backstage-cli prepack",
-    "postpack": "backstage-cli postpack",
-    "clean": "backstage-cli clean"
+    "build": "backstage-cli package build",
+    "start": "backstage-cli package start",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test",
+    "prepack": "backstage-cli package prepack",
+    "postpack": "backstage-cli package postpack",
+    "clean": "backstage-cli package clean"
   },
   "dependencies": {
     "@backstage/catalog-model": "^1.0.0",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -19,6 +19,7 @@ export type Options = {
 export class HarborApiClient implements harborApi {
   // @ts-ignore
   private readonly discoveryApi: DiscoveryApi
+  // @ts-ignore
   private readonly fetchApi: FetchApi
 
   constructor(options: Options) {

--- a/src/components/HarborDashboardPage/HarborDashboardPage.tsx
+++ b/src/components/HarborDashboardPage/HarborDashboardPage.tsx
@@ -12,8 +12,8 @@ export const HarborDashboardPage = () => {
     <Grid container spacing={3}>
       {repositorySlug.split(', ').map((slug) => {
         const info = slug.split('/')
-        const host: string = info.length > 2 ? info.shift() : ''
-        const project: string = info.shift()
+        const host: string = info.length > 2 ? info.shift() as string : ''
+        const project: string = info.shift() as string
         const repository: string = info.join('/')
 
         return (

--- a/src/components/HarborRepository/HarborRepository.tsx
+++ b/src/components/HarborRepository/HarborRepository.tsx
@@ -89,9 +89,7 @@ export function HarborRepository(props: RepositoryProps) {
             '#ff471a',
           ]}
           customSegmentStops={[0, 100, 200, 300, 400, 500]}
-          currentValueText={`${props.host}${props.host ? '/' : ''}${
-            props.project
-          }/${props.repository}`}
+          currentValueText={truncateGraphDescription(props.host, props.project, props.repository)}
           customSegmentLabels={[
             {
               text: 'None',
@@ -124,6 +122,20 @@ export function HarborRepository(props: RepositoryProps) {
       />
     </div>
   )
+}
+
+function truncateGraphDescription (host: string, project: string, repository: string) {
+  let descriptionString = `${host}${host ? '/' : ''}${
+    project
+  }/${repository}`
+  if (descriptionString.length > 38) {
+    descriptionString = `${project}/${repository}`
+    if (descriptionString.length > 38) {
+      return repository
+    }
+    return descriptionString
+  }
+  return descriptionString;
 }
 
 HarborRepository.defaultProps = {

--- a/src/components/HarborWidget/HarborWidget.tsx
+++ b/src/components/HarborWidget/HarborWidget.tsx
@@ -19,8 +19,8 @@ const Widget = ({ entity }: { entity: Entity }) => {
       <Grid container>
         {repositorySlug.split(', ').map((slug) => {
           const info = slug.split('/')
-          const host: string = info.length > 2 ? info.shift() : ''
-          const project: string = info.shift()
+          const host: string = info.length > 2 ? info.shift() as string : ''
+          const project: string = info.shift() as string
           const repository: string = info.join('/')
 
           return (


### PR DESCRIPTION
Hey,
when we have added Harbor Widget to our Backstage instance we noticed that the `descriptionString` is cut if too long and we are unable to see the Harbor repository name. 
![image](https://github.com/container-registry/backstage-plugin-harbor/assets/26680362/4e333b64-413e-453f-9be7-34e667f3e157)
In the screenshot above you can see that we can only see the part of the `harbor host url` and part of the `harbor project name`.
This PR adds length check of the `descriptionString` and if it's too long it removes `host` from it, if it's still too long it returns only the `repository`.
Result:
![image](https://github.com/container-registry/backstage-plugin-harbor/assets/26680362/9e6a0b54-f14d-4cff-add4-cd31960dc1c6)
Now there is a `project/repository` visible