### PR TITLE
Bump versions of d3 components

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     "@backstage/plugin-catalog-react": "^1.0.0",
     "@backstage/theme": "^0.4.0",
     "@material-ui/core": "^4.12.4",
-    "d3-selection": "^2",
-    "d3-transition": "^2",
-    "react-d3-speedometer": "^1.0.2",
+    "d3-selection": "^3",
+    "d3-transition": "^3",
+    "react-d3-speedometer": "^2",
     "react-use": "^17.2.4"
   },
   "peerDependencies": {


### PR DESCRIPTION
This adresses issue: https://github.com/container-registry/backstage-plugin-harbor/issues/269

This in part superseeds PRs:
- https://github.com/container-registry/backstage-plugin-harbor/pull/249
- https://github.com/container-registry/backstage-plugin-harbor/pull/247